### PR TITLE
Add description for flag 1 << 11

### DIFF
--- a/flags.md
+++ b/flags.md
@@ -11,7 +11,7 @@
 | 256    | 1<<8    | HYPESQUAD_ONLINE_HOUSE_3   | HypeSquad Online House Balance                    | ✓      |
 | 512    | 1<<9    | PREMIUM_EARLY_SUPPORTER    | Early Supporter                                   | ✓      |
 | 1024   | 1<<10   | TEAM_USER                  | Team User                                         | ✓      |
-| 2048   | 1<<11   |                            |                                                   |        |
+| 2048   | 1<<11   |                            | Relates to partner/verification applications.     |        |
 | 4096   | 1<<12   | SYSTEM                     | System User                                       | ✓      |
 | 8192   | 1<<13   | HAS_UNREAD_URGENT_MESSAGES | Has an unread system message                      |        |
 | 16384  | 1<<14   | BUG_HUNTER_LEVEL_2         | Bug Hunter Level 2                                | ✓      |


### PR DESCRIPTION
The `1 << 11` was accidentally leaked by Discord's API as confirmed [here](https://github.com/discord/discord-api-docs/issues/1823#issuecomment-661985807) by night.
We also brought the flag up for discussion with Mason, who gave us this answer:
![image](https://user-images.githubusercontent.com/17235016/99672158-545e3d80-2a73-11eb-999c-79fac1c6ebcd.png)
Sadly we weren't able to find out the internal name for it, so I left it blank.
