### PR TITLE
add discordvibeapps.com & vibeyard.tools

### DIFF
--- a/domains.md
+++ b/domains.md
@@ -25,6 +25,8 @@
 | discordstatus.com      | Status page                              |
 | discordpartygames.com  | Voice channel activity API host          |
 | discord-activities.com | Voice channel activity API host          |
+| discordvibeapps.com    | Unknown right now                        |
+
 
 ## Other
 

--- a/domains.md
+++ b/domains.md
@@ -25,7 +25,8 @@
 | discordstatus.com      | Status page                              |
 | discordpartygames.com  | Voice channel activity API host          |
 | discord-activities.com | Voice channel activity API host          |
-| discordvibeapps.com    | Unknown right now                        |
+| discordvibeapps.com    | Internal tool                            |
+| vibeyard.tools         | Internal tool                            |
 
 
 ## Other


### PR DESCRIPTION
This domain was just bought last day, and was added to canary web client CSP header. 
<img width="641" height="276" alt="image" src="https://github.com/user-attachments/assets/5579afe9-95fd-443c-b24f-dfb9512999f8" />

Will update description once I have more info, currently there is nothing in the web client using it.
